### PR TITLE
adding container development env & ShubProvisioner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ singularity-*.tar.gz
 .vscode
 vendor/
 buildtree/
+builddir/
 src/pkg/buildcfg/config.go
 trash.lock
 Makefile.in

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM iron/go:dev
+
+# Overview:
+# alpine image with the go tools for developing Singularity
+# you should bind your singularity/src folder to /code, or
+# develop in the container. If you do the first and make
+# changes in the container, be careful about permissions of the
+# files outside of the container (Docker runs as root user and o
+# the files will be root owned on the local development machine
+#
+# Building: 
+# docker build -t vanessa/singularity-dev .
+# 
+# Interactive Session
+# docker run -it --entrypoint sh vanessa/singularity-dev
+
+# For future - if we want the Dockerfile isolated from repo -
+#   We can take the repository username / branch as build-arg
+#   below shows setting defaults
+#   ARG REPO=singularityware
+#   ARG BRANCH=development-3.x
+#   and then clone the repository here (instead of ADD . /code)
+
+RUN echo "Installing build dependencies!\n" && \
+    apk add --update alpine-sdk linux-headers \
+                     e2fsprogs bash tar rsync squashfs-tools \
+                     openssl-dev util-linux-dev
+
+WORKDIR /code
+ENV SRC_DIR=/go/src/github.com/singularityware/singularity
+ADD . $SRC_DIR
+WORKDIR $SRC_DIR
+
+# Dependencies
+RUN go get -v github.com/golang/dep/cmd/dep && \
+    dep ensure -v
+
+# Compile the Singularity binary
+RUN ./mconfig && \
+    cd ./builddir && \
+    make dep && make && make install
+
+ENTRYPOINT ["singularity"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,12 @@ RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh && 
     dep ensure -vendor-only
 
 # Compile the Singularity binary
-RUN ./mconfig && \
-     cd ./builddir && \
-    make dep && make && make install
+RUN rm -rf ./builddir && ./mconfig && \
+#     cd ./builddir && \
+#    make dep && make && make install
 
-WORKDIR $SRC_DIR
-RUN test -z $(go fmt ./...)
+#WORKDIR $SRC_DIR
+#RUN test -z $(go fmt ./...)
 
 # HEALTHCHECK go test ./tests/
 

--- a/src/cmd/singularity/cli.go
+++ b/src/cmd/singularity/cli.go
@@ -9,5 +9,7 @@ package main
 import "github.com/singularityware/singularity/src/cmd/singularity/cli"
 
 func main() {
+
+	// In cli/singularity.go
 	cli.ExecuteSingularity()
 }

--- a/src/cmd/singularity/cli/singularity.go
+++ b/src/cmd/singularity/cli/singularity.go
@@ -32,8 +32,8 @@ var singularityCmd = &cobra.Command{
 
 /*
 Execute adds all child commands to the root command and sets flags
-appropriately.  This is called by main.main(). It only needs to happen once to
-the root command (singularity).
+appropriately.  This is called by main.main() in cli.go.
+It only needs to happen once to the root command (singularity).
 */
 func ExecuteSingularity() {
 	if err := singularityCmd.Execute(); err != nil {

--- a/src/pkg/build/provisioners/provisioner_shub.go
+++ b/src/pkg/build/provisioners/provisioner_shub.go
@@ -18,6 +18,7 @@ import (
 //        "log"
 	"os"
         "time"
+        "strings"
 
 	"github.com/containers/image/docker"
 	"github.com/containers/image/types"
@@ -37,7 +38,7 @@ type ShubClient struct {
 // NewRemoteBuilder creates a RemoteBuilder with the specified details.
 func NewShubClient(uri string) (shubClient *ShubClient) {
 
-	sylog.Infof("%v", uri)
+	sylog.Infof("%v\n", uri)
 	httpAddr := fmt.Sprintf("www.singularity-hub.org")
 	shubClient = &ShubClient{
 		Client: http.Client{
@@ -55,13 +56,17 @@ func (p *ShubProvisioner) getManifest() (err error) {
 	// Create a new Singularity Hub client
 	sc := &ShubClient{}
 
+        // TODO: need to parse the tag / digest and send along too
+        uri := strings.Split(p.srcRef.StringWithinTransport(), ":")[0]
+
 	// Format the http address, coinciding with the image uri
-	httpAddr := fmt.Sprintf("/container/%s", p.srcRef)
-	sylog.Infof("%v", httpAddr)
+	httpAddr := fmt.Sprintf("www.singularity-hub.org/api/container%s/", uri)
+	sylog.Infof("%v\n", httpAddr)
 
 	// Create the request, add headers context
-	url := url.URL{Scheme: "http", Host: sc.HTTPAddr, Path: httpAddr}
-	req, err := http.NewRequest(http.MethodPost, url.String(), nil)
+	url := url.URL{Scheme: "https", Host: sc.HTTPAddr, Path: httpAddr}
+        sylog.Infof("%v\n", url)
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 	if err != nil {
 		return
 	}
@@ -125,7 +130,6 @@ func (p *ShubProvisioner) Provision(i *image.Sandbox) (err error) {
 
 	// Get the image manifest
 	manifest := p.getManifest()
-	println(manifest)
 	sylog.Infof("%v", manifest)
 
 	// retrieve the image

--- a/src/pkg/build/provisioners/provisioner_shub.go
+++ b/src/pkg/build/provisioners/provisioner_shub.go
@@ -9,23 +9,139 @@
 package provisioners
 
 import (
+	"encoding/json"
+        "errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+//        "log"
+	"os"
+        "time"
 
+	"github.com/containers/image/docker"
+	"github.com/containers/image/types"
+	oci "github.com/containers/image/oci/layout"
 	"github.com/singularityware/singularity/src/pkg/image"
+	"github.com/singularityware/singularity/src/pkg/sylog"
 )
 
-// ShubProvisioner provisions a sandbox environment from a shub
-// URI.
+
+// ShubClient contains the uri and client
+type ShubClient struct {
+	Client   http.Client
+	ImageUri string
+	HTTPAddr string
+}
+
+// NewRemoteBuilder creates a RemoteBuilder with the specified details.
+func NewShubClient(uri string) (shubClient *ShubClient) {
+
+	sylog.Infof("%v", uri)
+	httpAddr := fmt.Sprintf("www.singularity-hub.org")
+	shubClient = &ShubClient{
+		Client: http.Client{
+			Timeout: 30 * time.Second,
+		},
+		HTTPAddr: httpAddr,
+		ImageUri: uri,
+	}
+
+	return
+}
+
+func (p *ShubProvisioner) getManifest() (err error) {
+
+	// Create a new Singularity Hub client
+	sc := &ShubClient{}
+
+	// Format the http address, coinciding with the image uri
+	httpAddr := fmt.Sprintf("/container/%s", p.srcRef)
+	sylog.Infof("%v", httpAddr)
+
+	// Create the request, add headers context
+	url := url.URL{Scheme: "http", Host: sc.HTTPAddr, Path: httpAddr}
+	req, err := http.NewRequest(http.MethodPost, url.String(), nil)
+	if err != nil {
+		return
+	}
+
+	// Do the request, if status isn't success, return error
+	res, err := sc.Client.Do(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		err = errors.New(res.Status)
+		return
+	}
+
+	err = json.NewDecoder(res.Body).Decode(&p)
+	return
+
+}
+
+// NewShubProvisioner returns a provisioner that can dump a previously
+// build Singularity image into a sandbox based on a URI
+func NewShubProvisioner(src string) (p *ShubProvisioner, err error) {
+
+	// Question for bauerm - where does this get called?
+	p = &ShubProvisioner{}
+
+	// Shub URI largely follows same namespace convention
+	p.srcRef, err = docker.ParseReference(src)
+	if err != nil {
+		return &ShubProvisioner{}, err
+	}
+
+	p.tmpfs, err = ioutil.TempDir("", "temp-oci-")
+	if err != nil {
+		return &ShubProvisioner{}, err
+	}
+
+	p.tmpfsRef, err = oci.ParseReference(p.tmpfs + ":" + "tmp")
+	if err != nil {
+		return &ShubProvisioner{}, err
+	}
+
+	return p, nil
+}
+
+// ShubProvisioner provisions a sandbox environment from a shub URI.
 type ShubProvisioner struct {
+	src      string
+	srcRef   types.ImageReference
+	tmpfs    string
+	tmpfsRef types.ImageReference
 }
 
 // Provision provisions a sandbox from the Shub source URI into the location
 // specified by i.
 func (p *ShubProvisioner) Provision(i *image.Sandbox) (err error) {
-	return fmt.Errorf("Shub provisioner not implemented yet")
-}
 
-// NewShubProvisioner returns a ShubProvisioner object from the Shub source
-func NewShubProvisioner(src string) (p *ShubProvisioner, err error) {
-	return &ShubProvisioner{}, fmt.Errorf("Shub provisioner not supported yet")
+	defer os.RemoveAll(p.tmpfs)
+
+	// Get the image manifest
+	manifest := p.getManifest()
+	println(manifest)
+	sylog.Infof("%v", manifest)
+
+	// retrieve the image
+	//err = p.fetch(i)
+	//if err != nil {
+	//	log.Fatal(err)
+	//	return
+	//}
+
+	//err = p.unpackTmpfs(i)
+	//if err != nil {
+	//	log.Fatal(err)
+	//	return
+	//}
+
+	return nil
+
+	return fmt.Errorf("Shub provisioner not implemented yet")
 }


### PR DESCRIPTION
**Description of the Pull Request (PR):**

Hey @bauerm97 ! I stepped back and decided that before trying to implement the Shub endpoint feature, it would be reasonable to have a clean method to reproduce my development workflow, period. The easiest thing (I think) to do is to create a Dockerfile (to live with a respective development repository) where a developer can just build the image and go! (no pun intended, har har.)

** update ** have fixed previous issues!

**Building**

```bash
$ docker build -t vanessa/singularity-dev .
```

**Interactive Session**
```bash
$ docker run --privileged -it --entrypoint bash vanessa/singularity-dev
```

**Testing**
```bash
$ docker run --privileged -it --entrypoint go vanessa/singularity-dev test ./tests/
```

A few notes:
 - A more detailed description of these commands is in the header of the Dockerfile
 - I didn't see where the CHANGELOG went? I would want to add the note about the Dockerfile here.
 - The alpine base is the most common for go development, and I originally chose it. The make process failed, likely because of library mismatches, so I went back to debian. Maybe in the future we could revisit alphine because it's much smaller.
- if/when we get this working, there should be a place to write instructions for using it. The logical place would be Singularity docs, and I can start with a markdown post somewhere,
- Derivations of the above can do things like bind the local directory to /code, etc.

Now I'll work on that other thing :)